### PR TITLE
Added ability to add an entry point

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.13"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
     name: pyTest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/docker_build/docker.py
+++ b/docker_build/docker.py
@@ -46,7 +46,8 @@ class Docker(object):
             config_files: list[str],
             binaries: list[str],
             exposed_ports: list[ExposedPortDetails],
-            commands: list[str]
+            commands: list[str],
+            entry_point: str | None = None,
     ):
         """
         Build a dockerfile based on the inputs.
@@ -56,6 +57,7 @@ class Docker(object):
             binaries: List of binary files to copy out of the origin container
             exposed_ports: Ports to be exposed
             commands: List of commands to be run during making of the container
+            entry_point: Entry point to be set in the container
         """
         self._dockerfile.add_commands(commands=commands)
         self._dockerfile.add_exposed_ports(exposed_ports=exposed_ports)
@@ -63,7 +65,7 @@ class Docker(object):
         self._process_binaries(binaries=binaries)
         self._process_config_files(config_files=config_files)
 
-        self._dockerfile.build(save_path=self._base_path)
+        self._dockerfile.build(save_path=self._base_path, entry_point=entry_point)
 
     def _copy_file(self, file_details: FileDetails):
         """

--- a/docker_build/dockerfile.py
+++ b/docker_build/dockerfile.py
@@ -69,12 +69,13 @@ class Dockerfile(object):
             self._files.append(files)
             return
 
-    def build(self, save_path: Path):
+    def build(self, save_path: Path, entry_point: str | None = None):
         """
         Build the dockerfile and save it in the specified path.
 
         Args:
             save_path: Path and filename to save the Dockerfile too
+            entry_point: Entry point to be set in the container
         """
         output = f'FROM {self._base_image}\n\n'
 
@@ -94,6 +95,9 @@ class Dockerfile(object):
             if exposed_port.protocol:
                 output += f'/{exposed_port.protocol}'
             output += '\n'
+
+        if entry_point:
+            output += f'ENTRYPOINT {entry_point}\n'
 
         with open(save_path.joinpath('Dockerfile'), 'w') as fh:
             fh.write(output)


### PR DESCRIPTION
Added ability to add an entry point into the docker container.

## Summary by Sourcery

Add support for specifying a container entry point in the Dockerfile generation process.

New Features:
- Introduce an optional entry_point parameter to the run function for Docker builds.
- Extend the Dockerfile build step to include an ENTRYPOINT instruction when provided.